### PR TITLE
Catch exceptions instead of letting Sopel spit out "Unexpected error"

### DIFF
--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -142,12 +142,10 @@ def get_geocoords(bot, trigger):
         'addressdetails': 1,
         'limit': 1
     }
-    try:
-        r = requests.get(url, params=data)
-        if r.status_code != 200:
-            raise Exception(r.json()['error'])
-    except:
-        raise Exception("An Error Occurred. Check Logs For More Information.")
+
+    r = requests.get(url, params=data)
+    if r.status_code != 200:
+        raise Exception(r.json()['error'])
 
     latitude = r.json()[0]['lat']
     longitude = r.json()[0]['lon']
@@ -242,7 +240,12 @@ def weather_command(bot, trigger):
                            "London, for example.".format(command=trigger.group(1),
                                                          pfx=bot.config.core.help_prefix))
 
-    data = get_weather(bot, trigger)
+    try:
+        data = get_weather(bot, trigger)
+    except Exception as err:
+        bot.reply("Could not get weather: " + str(err))
+        return
+
     weather = u'{location}: {temp}, {condition}, {humidity}'.format(
         location=data['location'],
         temp=get_temp(data['temp']),
@@ -283,7 +286,12 @@ def forecast_command(bot, trigger):
                            "London, for example.".format(command=trigger.group(1),
                                                          pfx=bot.config.core.help_prefix))
 
-    data = get_forecast(bot, trigger)
+    try:
+        data = get_forecast(bot, trigger)
+    except Exception as err:
+        bot.reply("Could not get forecast: " + str(err))
+        return
+
     forecast = '{location}'.format(location=data['location'])
     for day in data['data']:
         forecast += ' :: {dow} - {summary} - {high_temp} / {low_temp}'.format(
@@ -311,7 +319,12 @@ def update_location(bot, trigger):
         return NOLIMIT
 
     # Get GeoCoords
-    latitude, longitude, location = get_geocoords(bot, trigger)
+    try:
+        latitude, longitude, location = get_geocoords(bot, trigger)
+    except Exception as err:
+        # Reply with the error message if geocoding fails
+        bot.reply("Could not find location details: " + str(err))
+        return
 
     # Assign Latitude & Longitude to user
     bot.db.set_nick_value(trigger.nick, 'latitude', latitude)

--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -143,7 +143,13 @@ def get_geocoords(bot, trigger):
         'limit': 1
     }
 
-    r = requests.get(url, params=data)
+    try:
+        r = requests.get(url, params=data)
+    except requests.exceptions.RequestException:
+        # requests likes to include the full URL in its exceptions, which would
+        # mean the API key gets printed to the channel
+        raise Exception("Could not geocode location. See logs for details.")
+
     if r.status_code != 200:
         raise Exception(r.json()['error'])
 


### PR DESCRIPTION
Tin. It's much faster for the user to see what went wrong and whether they need a bot admin to fix it if the actual error from LocationIQ comes through. Can be more specific if you want, but it's probably good enough this way.

Didn't touch the weather providers' vague "friendly" message about checking logs, because once the location is successfully geocoded there's absolutely no way it could be user error any more.

You can test the behavior of this patch as I did by doing e.g. `.wea notanick`, which is apparently not close enough to any real location name to match and LocationIQ will return an error. PMing the bot `.set weather.geocoords_api_key asdfghjkl` should show you what happens if the key is invalid, for example. (Restarting the test bot will revert to the configured key, unless you accidentally PM the bot `.save`.)