### PR TITLE
Python 3.6 is not available for ubuntu-latest any more

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,10 +10,15 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        python-version: [3.7, 3.8, 3.9]
+        include:
+          - python-version: 3.6
+            os: ubuntu-20.04
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Have to select ubuntu-20.04 specifically to run Python 3.6 tests.

Once this is applied, it should be possible to make #40 pass checks. Might have to be rebased first; we'll see.