### PR TITLE
openmeteo: API now handles URI-encoded commas properly

### DIFF
--- a/sopel_modules/weather/providers/weather/openmeteo.py
+++ b/sopel_modules/weather/providers/weather/openmeteo.py
@@ -45,11 +45,7 @@ def openmeteo_forecast(bot, latitude, longitude, location):
     params = {
         'latitude': latitude,
         'longitude': longitude,
-        'daily': [
-            'temperature_2m_min',
-            'temperature_2m_max',
-            'weathercode',
-        ],
+        'daily': 'temperature_2m_min,temperature_2m_max,weathercode',
         'timeformat': 'unixtime',
         'timezone': 'auto',
     }
@@ -86,7 +82,7 @@ def openmeteo_weather(bot, latitude, longitude, location):
         'current_weather': 1,
         'windspeed_unit': 'ms',
         'hourly': 'relativehumidity_2m',
-        'daily': ['sunrise', 'sunset'],
+        'daily': 'sunrise,sunset',
         'timeformat': 'unixtime',
         'timezone': 'auto',
     }


### PR DESCRIPTION
We can go back to the original parameter style I wanted to use for daily & hourly fields, and stop sending API requests with a bunch of redundant field names due to how requests builds GET URIs from array params.

This is thanks to https://github.com/open-meteo/open-meteo/commit/5fd0cd1fcf21df4577f4ad9eda95d7a5e699d0db fixing open-meteo/open-meteo#192