### PR TITLE
Add Pirate Weather provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,14 @@ OpenWeatherMap
 
     https://openweathermap.org/
 
+Pirate Weather
+
+A drop-in replacement API for the old Dark Sky service bought by Apple.
+
+.. code-block::
+
+    https://pirateweather.net/
+
 Python Requirements
 ~~~~~~~~~~~~~~~~~~~
 .. code-block::

--- a/sopel_modules/weather/providers/weather/pirateweather.py
+++ b/sopel_modules/weather/providers/weather/pirateweather.py
@@ -1,0 +1,70 @@
+# coding=utf-8
+import requests
+
+from datetime import datetime
+
+
+def pirateweather_forecast(bot, latitude, longitude, location):
+    url = 'https://api.pirateweather.net/forecast/{}/{},{}'.format(
+        bot.config.weather.weather_api_key,
+        latitude,
+        longitude
+    )
+
+    params = {
+        'exclude': 'currently,minutely,hourly,alerts,flags',  # Exclude extra data we don't want/need
+        'units': 'si'
+    }
+    try:
+        r = requests.get(url, params=params)
+    except:
+        raise Exception("An Error Occurred. Check Logs For More Information.")
+    data = r.json()
+    if r.status_code != 200:
+        raise Exception('Error: {}'.format(data['error']))
+    else:
+        weather_data = {'location': location, 'data': []}
+        for day in data['daily']['data'][0:4]:
+            weather_data['data'].append({
+                'dow': datetime.fromtimestamp(day['time']).strftime('%A'),
+                'summary': day['summary'].strip('.'),
+                'high_temp': day['temperatureHigh'],
+                'low_temp': day['temperatureLow']
+            })
+        return weather_data
+
+
+def pirateweather_weather(bot, latitude, longitude, location):
+    url = 'https://api.pirateweather.net/forecast/{}/{},{}'.format(
+        bot.config.weather.weather_api_key,
+        latitude,
+        longitude
+    )
+
+    params = {
+        'exclude': 'minutely,hourly,alerts,flags',  # Exclude extra data we don't want/need
+        'units': 'si',
+    }
+    try:
+        r = requests.get(url, params=params)
+    except:
+        raise Exception("An Error Occurred. Check Logs For More Information.")
+    data = r.json()
+    if r.status_code != 200:
+        raise Exception('Error: {}'.format(data['error']))
+    else:
+        weather_data = {
+            'location': location,
+            'temp': data['currently']['temperature'],
+            'condition': data['currently']['summary'],
+            'humidity': data['currently']['humidity'],
+            'wind': {'speed': data['currently']['windSpeed'], 'bearing': data['currently']['windBearing']},
+            'uvindex': data['currently']['uvIndex'],
+            'timezone': data['timezone'],
+        }
+
+        if bot.config.weather.sunrise_sunset:
+            weather_data['sunrise'] = data['daily']['data'][0]['sunriseTime']
+            weather_data['sunset'] = data['daily']['data'][0]['sunsetTime']
+
+        return weather_data

--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -20,11 +20,13 @@ from sopel.tools.time import format_time
 from .providers.weather.darksky import darksky_forecast, darksky_weather
 from .providers.weather.openmeteo import openmeteo_forecast, openmeteo_weather
 from .providers.weather.openweathermap import openweathermap_forecast, openweathermap_weather
+from .providers.weather.pirateweather import pirateweather_forecast, pirateweather_weather
 
 WEATHER_PROVIDERS = [
     'darksky',
     'openmeteo',
     'openweathermap',
+    'pirateweather',
 ]
 
 GEOCOORDS_PROVIDERS = {
@@ -246,6 +248,9 @@ def get_forecast(bot, trigger):
     # OpenWeatherMap
     elif bot.config.weather.weather_provider == 'openweathermap':
         return openweathermap_forecast(bot, latitude, longitude, location)
+    # Pirate Weather
+    elif bot.config.weather.weather_provider == 'pirateweather':
+        return pirateweather_forecast(bot, latitude, longitude, location)
     # Unsupported Provider
     else:
         raise Exception('Error: Unsupported Provider')
@@ -267,6 +272,9 @@ def get_weather(bot, trigger):
     # OpenWeatherMap
     elif bot.config.weather.weather_provider == 'openweathermap':
         return openweathermap_weather(bot, latitude, longitude, location)
+    # Pirate Weather
+    elif bot.config.weather.weather_provider == 'pirateweather':
+        return pirateweather_weather(bot, latitude, longitude, location)
     # Unsupported Provider
     else:
         raise Exception('Error: Unsupported Provider')


### PR DESCRIPTION
https://pirateweather.net/ provides a drop-in replacement for the Dark Sky API.

I've implemented this patch in a way that should, hopefully, avoid merge conflicts with #40. This can be tested separately from the removal of the still-working-for-four-more-days Dark Sky provider.

@RustyBower I PM'd you an API key on IRC, for testing. It takes 20-30 mins for activation, according to their docs, so even I haven't tested this yet. 😅