### PR TITLE
Sopel 8 preparations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-sopel
+sopel>=7.1
 pytz

--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 import pytz
 
-from sopel.config.types import NO_DEFAULT, ChoiceAttribute, StaticSection, ValidatedAttribute
+from sopel.config.types import NO_DEFAULT, BooleanAttribute, ChoiceAttribute, StaticSection, ValidatedAttribute
 from sopel.plugin import commands, example, NOLIMIT
 from sopel.tools import Identifier
 from sopel.tools.time import format_time
@@ -42,8 +42,8 @@ class WeatherSection(StaticSection):
     geocoords_api_key = ValidatedAttribute('geocoords_api_key', str, default='')
     weather_provider = ChoiceAttribute('weather_provider', WEATHER_PROVIDERS, default=NO_DEFAULT)
     weather_api_key = ValidatedAttribute('weather_api_key', str, default='')
-    sunrise_sunset = ValidatedAttribute('sunrise_sunset', bool, default=False)
-    nick_lookup = ValidatedAttribute('nick_lookup', bool, default=True)
+    sunrise_sunset = BooleanAttribute('sunrise_sunset', default=False)
+    nick_lookup = BooleanAttribute('nick_lookup', default=True)
 
 
 def setup(bot):

--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -13,7 +13,6 @@ import pytz
 
 from sopel.config.types import NO_DEFAULT, ChoiceAttribute, StaticSection, ValidatedAttribute
 from sopel.plugin import commands, example, NOLIMIT
-from sopel.modules.units import c_to_f
 from sopel.tools import Identifier
 from sopel.tools.time import format_time
 
@@ -91,7 +90,7 @@ def get_temp(temp):
         temp = float(temp)
     except (KeyError, TypeError, ValueError):
         return 'unknown'
-    return u'%d\u00B0C (%d\u00B0F)' % (round(temp), round(c_to_f(temp)))
+    return u'%d\u00B0C (%d\u00B0F)' % (round(temp), round(1.8 * temp + 32))
 
 
 def get_humidity(humidity):

--- a/sopel_modules/weather/weather.py
+++ b/sopel_modules/weather/weather.py
@@ -12,7 +12,7 @@ from datetime import datetime
 import pytz
 
 from sopel.config.types import NO_DEFAULT, ChoiceAttribute, StaticSection, ValidatedAttribute
-from sopel.module import commands, example, NOLIMIT
+from sopel.plugin import commands, example, NOLIMIT
 from sopel.modules.units import c_to_f
 from sopel.tools import Identifier
 from sopel.tools.time import format_time


### PR DESCRIPTION
* Fixed deprecated import (`sopel.module` -> `sopel.plugin`)
* Switch to `BooleanAttribute` instead of `ValidatedAttribute` with `bool` as parser
* Just calculate °C -> °F by formula instead of importing non-public function in core

Note that all of these changes are still compatible with Sopel 7.1+ and do not require 8.0.